### PR TITLE
Start C# port - Terminal layer skeleton

### DIFF
--- a/cssrc/Lanterna/Graphics/ITextGraphics.cs
+++ b/cssrc/Lanterna/Graphics/ITextGraphics.cs
@@ -1,0 +1,9 @@
+namespace Lanterna.Graphics
+{
+    /// <summary>
+    /// Placeholder interface for drawing text graphics directly on a terminal.
+    /// </summary>
+    public interface ITextGraphics
+    {
+    }
+}

--- a/cssrc/Lanterna/Input/IInputProvider.cs
+++ b/cssrc/Lanterna/Input/IInputProvider.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Lanterna.Input
+{
+    /// <summary>
+    /// Interface describing an object that can provide keyboard input.
+    /// </summary>
+    public interface IInputProvider
+    {
+        /// <summary>
+        /// Returns the next available keystroke if one is waiting, otherwise null.
+        /// </summary>
+        /// <returns>The next keystroke or null.</returns>
+        KeyStroke? PollInput();
+
+        /// <summary>
+        /// Blocks until a keystroke is available and returns it.
+        /// </summary>
+        /// <returns>The next keystroke.</returns>
+        KeyStroke ReadInput();
+    }
+}

--- a/cssrc/Lanterna/Input/KeyStroke.cs
+++ b/cssrc/Lanterna/Input/KeyStroke.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace Lanterna.Input
+{
+    /// <summary>
+    /// Basic representation of a key event. This is a minimal
+    /// subset of the Java KeyStroke class used by Lanterna.
+    /// </summary>
+    public class KeyStroke
+    {
+        public KeyType KeyType { get; }
+        public char? Character { get; }
+        public bool CtrlDown { get; }
+        public bool AltDown { get; }
+        public bool ShiftDown { get; }
+        public long EventTime { get; }
+
+        public KeyStroke(KeyType keyType)
+            : this(keyType, null, false, false, false)
+        {
+        }
+
+        public KeyStroke(KeyType keyType, bool ctrlDown, bool altDown, bool shiftDown = false)
+            : this(keyType, null, ctrlDown, altDown, shiftDown)
+        {
+        }
+
+        public KeyStroke(char character, bool ctrlDown = false, bool altDown = false)
+            : this(KeyType.Character, character, ctrlDown, altDown, false)
+        {
+        }
+
+        public KeyStroke(KeyType keyType, char? character, bool ctrlDown, bool altDown, bool shiftDown)
+        {
+            if (keyType == KeyType.Character && character == null)
+                throw new ArgumentException("Character must be specified when key type is Character");
+
+            KeyType = keyType;
+            Character = character;
+            CtrlDown = ctrlDown;
+            AltDown = altDown;
+            ShiftDown = shiftDown;
+            EventTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        }
+    }
+}

--- a/cssrc/Lanterna/Input/KeyType.cs
+++ b/cssrc/Lanterna/Input/KeyType.cs
@@ -1,0 +1,50 @@
+namespace Lanterna.Input
+{
+    /// <summary>
+    /// Enumeration describing the kind of key pressed.
+    /// This mirrors the KeyType enum from the Java implementation.
+    /// </summary>
+    public enum KeyType
+    {
+        Character,
+        Escape,
+        Backspace,
+        ArrowLeft,
+        ArrowRight,
+        ArrowUp,
+        ArrowDown,
+        Insert,
+        Delete,
+        Home,
+        End,
+        PageUp,
+        PageDown,
+        Tab,
+        ReverseTab,
+        Enter,
+        F1,
+        F2,
+        F3,
+        F4,
+        F5,
+        F6,
+        F7,
+        F8,
+        F9,
+        F10,
+        F11,
+        F12,
+        F13,
+        F14,
+        F15,
+        F16,
+        F17,
+        F18,
+        F19,
+        KeyTypeMarker,
+        // Virtual key types
+        CursorLocation,
+        MouseEvent,
+        Eof
+    }
+}

--- a/cssrc/Lanterna/Terminal/AbstractTerminal.cs
+++ b/cssrc/Lanterna/Terminal/AbstractTerminal.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using Lanterna.Graphics;
+
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Base class with resize listener management and default TextGraphics implementation.
+    /// </summary>
+    public abstract class AbstractTerminal : Terminal
+    {
+        private readonly List<TerminalResizeListener> _resizeListeners = new();
+        private TerminalSize? _lastKnownSize;
+
+        public virtual void AddResizeListener(TerminalResizeListener listener)
+        {
+            if (listener != null)
+                _resizeListeners.Add(listener);
+        }
+
+        public virtual void RemoveResizeListener(TerminalResizeListener listener)
+        {
+            if (listener != null)
+                _resizeListeners.Remove(listener);
+        }
+
+        protected void OnResized(TerminalSize size)
+        {
+            if (_lastKnownSize == null || !_lastKnownSize.Equals(size))
+            {
+                _lastKnownSize = size;
+                foreach (var l in _resizeListeners)
+                    l.OnResized(this, size);
+            }
+        }
+
+        public virtual ITextGraphics NewTextGraphics()
+        {
+            return new TerminalTextGraphics(this);
+        }
+
+        // Other Terminal methods remain abstract
+        public abstract void EnterPrivateMode();
+        public abstract void ExitPrivateMode();
+        public abstract void ClearScreen();
+        public abstract void SetCursorPosition(int x, int y);
+        public abstract void SetCursorPosition(TerminalPosition position);
+        public abstract TerminalPosition GetCursorPosition();
+        public abstract void SetCursorVisible(bool visible);
+        public abstract void PutCharacter(char c);
+        public abstract void PutString(string text);
+        public abstract void EnableSGR(SGR sgr);
+        public abstract void DisableSGR(SGR sgr);
+        public abstract void ResetColorAndSGR();
+        public abstract void SetForegroundColor(ITextColor color);
+        public abstract void SetBackgroundColor(ITextColor color);
+        public abstract TerminalSize GetTerminalSize();
+        public abstract byte[] EnquireTerminal(int timeoutMilliseconds);
+        public abstract void Bell();
+        public abstract void Flush();
+        public abstract Lanterna.Input.KeyStroke PollInput();
+        public abstract Lanterna.Input.KeyStroke ReadInput();
+        public abstract void Dispose();
+    }
+}

--- a/cssrc/Lanterna/Terminal/DefaultTerminalFactory.cs
+++ b/cssrc/Lanterna/Terminal/DefaultTerminalFactory.cs
@@ -1,0 +1,14 @@
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Simplified default implementation returning a basic terminal.
+    /// The real Java version performs extensive detection; this stub just throws.
+    /// </summary>
+    public class DefaultTerminalFactory : TerminalFactory
+    {
+        public Terminal CreateTerminal()
+        {
+            throw new System.NotImplementedException("Terminal creation not implemented");
+        }
+    }
+}

--- a/cssrc/Lanterna/Terminal/ExtendedTerminal.cs
+++ b/cssrc/Lanterna/Terminal/ExtendedTerminal.cs
@@ -1,0 +1,19 @@
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Additional optional features for terminals.
+    /// </summary>
+    public interface ExtendedTerminal : Terminal
+    {
+        void SetTerminalSize(int columns, int rows);
+        void SetTitle(string title);
+        void PushTitle();
+        void PopTitle();
+        void Iconify();
+        void Deiconify();
+        void Maximize();
+        void Unmaximize();
+        void SetMouseCaptureMode(MouseCaptureMode mouseCaptureMode);
+        void ScrollLines(int firstLine, int lastLine, int distance);
+    }
+}

--- a/cssrc/Lanterna/Terminal/IOSafeExtendedTerminal.cs
+++ b/cssrc/Lanterna/Terminal/IOSafeExtendedTerminal.cs
@@ -1,0 +1,19 @@
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Combination of IOSafeTerminal and ExtendedTerminal.
+    /// </summary>
+    public interface IOSafeExtendedTerminal : IOSafeTerminal, ExtendedTerminal
+    {
+        new void SetTerminalSize(int columns, int rows);
+        new void SetTitle(string title);
+        new void PushTitle();
+        new void PopTitle();
+        new void Iconify();
+        new void Deiconify();
+        new void Maximize();
+        new void Unmaximize();
+        new void SetMouseCaptureMode(MouseCaptureMode mouseCaptureMode);
+        new void ScrollLines(int firstLine, int lastLine, int distance);
+    }
+}

--- a/cssrc/Lanterna/Terminal/IOSafeTerminal.cs
+++ b/cssrc/Lanterna/Terminal/IOSafeTerminal.cs
@@ -1,0 +1,32 @@
+using Lanterna.Input;
+
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Variant of Terminal that doesn't throw IOExceptions.
+    /// </summary>
+    public interface IOSafeTerminal : Terminal
+    {
+        new void EnterPrivateMode();
+        new void ExitPrivateMode();
+        new void ClearScreen();
+        new void SetCursorPosition(int x, int y);
+        new void SetCursorPosition(TerminalPosition position);
+        new TerminalPosition GetCursorPosition();
+        new void SetCursorVisible(bool visible);
+        new void PutCharacter(char c);
+        new void PutString(string text);
+        new Lanterna.Graphics.ITextGraphics NewTextGraphics();
+        new void EnableSGR(SGR sgr);
+        new void DisableSGR(SGR sgr);
+        new void ResetColorAndSGR();
+        new void SetForegroundColor(ITextColor color);
+        new void SetBackgroundColor(ITextColor color);
+        new TerminalSize GetTerminalSize();
+        new byte[] EnquireTerminal(int timeoutMilliseconds);
+        new void Bell();
+        new void Flush();
+        new KeyStroke PollInput();
+        new KeyStroke ReadInput();
+    }
+}

--- a/cssrc/Lanterna/Terminal/IOSafeTerminalAdapter.cs
+++ b/cssrc/Lanterna/Terminal/IOSafeTerminalAdapter.cs
@@ -1,0 +1,47 @@
+using Lanterna.Graphics;
+using Lanterna.Input;
+
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Utility for exposing a Terminal as IOSafeTerminal by converting IOExceptions to RuntimeExceptions.
+    /// This is a partial port of the Java class.
+    /// </summary>
+    public class IOSafeTerminalAdapter : IOSafeTerminal
+    {
+        private readonly Terminal _backend;
+
+        public IOSafeTerminalAdapter(Terminal backend)
+        {
+            _backend = backend;
+        }
+
+        public static IOSafeTerminal CreateRuntimeExceptionAdapter(Terminal terminal)
+            => new IOSafeTerminalAdapter(terminal);
+
+        public void EnterPrivateMode() => _backend.EnterPrivateMode();
+        public void ExitPrivateMode() => _backend.ExitPrivateMode();
+        public void ClearScreen() => _backend.ClearScreen();
+        public void SetCursorPosition(int x, int y) => _backend.SetCursorPosition(x, y);
+        public void SetCursorPosition(TerminalPosition position) => _backend.SetCursorPosition(position);
+        public TerminalPosition GetCursorPosition() => _backend.GetCursorPosition();
+        public void SetCursorVisible(bool visible) => _backend.SetCursorVisible(visible);
+        public void PutCharacter(char c) => _backend.PutCharacter(c);
+        public void PutString(string text) => _backend.PutString(text);
+        public ITextGraphics NewTextGraphics() => _backend.NewTextGraphics();
+        public void EnableSGR(SGR sgr) => _backend.EnableSGR(sgr);
+        public void DisableSGR(SGR sgr) => _backend.DisableSGR(sgr);
+        public void ResetColorAndSGR() => _backend.ResetColorAndSGR();
+        public void SetForegroundColor(ITextColor color) => _backend.SetForegroundColor(color);
+        public void SetBackgroundColor(ITextColor color) => _backend.SetBackgroundColor(color);
+        public void AddResizeListener(TerminalResizeListener listener) => _backend.AddResizeListener(listener);
+        public void RemoveResizeListener(TerminalResizeListener listener) => _backend.RemoveResizeListener(listener);
+        public TerminalSize GetTerminalSize() => _backend.GetTerminalSize();
+        public byte[] EnquireTerminal(int timeoutMilliseconds) => _backend.EnquireTerminal(timeoutMilliseconds);
+        public void Bell() => _backend.Bell();
+        public void Flush() => _backend.Flush();
+        public KeyStroke PollInput() => _backend.PollInput();
+        public KeyStroke ReadInput() => _backend.ReadInput();
+        public void Dispose() => _backend.Dispose();
+    }
+}

--- a/cssrc/Lanterna/Terminal/MouseCaptureMode.cs
+++ b/cssrc/Lanterna/Terminal/MouseCaptureMode.cs
@@ -1,0 +1,14 @@
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Modes for capturing mouse input. Behavior depends on the terminal emulator.
+    /// </summary>
+    public enum MouseCaptureMode
+    {
+        Click,
+        ClickRelease,
+        ClickReleaseDrag,
+        ClickReleaseDragMove,
+        ClickAutodetect
+    }
+}

--- a/cssrc/Lanterna/Terminal/SGR.cs
+++ b/cssrc/Lanterna/Terminal/SGR.cs
@@ -1,0 +1,18 @@
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Selected Graphic Rendition codes controlling text appearance.
+    /// </summary>
+    public enum SGR
+    {
+        Bold,
+        Reverse,
+        Underline,
+        Blink,
+        Bordered,
+        Fraktur,
+        CrossedOut,
+        Circled,
+        Italic
+    }
+}

--- a/cssrc/Lanterna/Terminal/SimpleTerminalResizeListener.cs
+++ b/cssrc/Lanterna/Terminal/SimpleTerminalResizeListener.cs
@@ -1,0 +1,37 @@
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Helper listener to keep track of terminal size changes.
+    /// </summary>
+    public class SimpleTerminalResizeListener : TerminalResizeListener
+    {
+        private bool _wasResized;
+        private TerminalSize _lastKnownSize;
+
+        public SimpleTerminalResizeListener(TerminalSize initialSize)
+        {
+            _lastKnownSize = initialSize;
+        }
+
+        /// <summary>
+        /// Returns true if a resize event was received since last call.
+        /// </summary>
+        public bool IsTerminalResized()
+        {
+            if (_wasResized)
+            {
+                _wasResized = false;
+                return true;
+            }
+            return false;
+        }
+
+        public TerminalSize LastKnownSize => _lastKnownSize;
+
+        public void OnResized(Terminal terminal, TerminalSize newSize)
+        {
+            _wasResized = true;
+            _lastKnownSize = newSize;
+        }
+    }
+}

--- a/cssrc/Lanterna/Terminal/Terminal.cs
+++ b/cssrc/Lanterna/Terminal/Terminal.cs
@@ -1,0 +1,34 @@
+using System;
+using Lanterna.Graphics;
+using Lanterna.Input;
+
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Low level terminal interface similar to the Java version.
+    /// </summary>
+    public interface Terminal : IInputProvider, IDisposable
+    {
+        void EnterPrivateMode();
+        void ExitPrivateMode();
+        void ClearScreen();
+        void SetCursorPosition(int x, int y);
+        void SetCursorPosition(TerminalPosition position);
+        TerminalPosition GetCursorPosition();
+        void SetCursorVisible(bool visible);
+        void PutCharacter(char c);
+        void PutString(string text);
+        Lanterna.Graphics.ITextGraphics NewTextGraphics();
+        void EnableSGR(SGR sgr);
+        void DisableSGR(SGR sgr);
+        void ResetColorAndSGR();
+        void SetForegroundColor(ITextColor color);
+        void SetBackgroundColor(ITextColor color);
+        void AddResizeListener(TerminalResizeListener listener);
+        void RemoveResizeListener(TerminalResizeListener listener);
+        TerminalSize GetTerminalSize();
+        byte[] EnquireTerminal(int timeoutMilliseconds);
+        void Bell();
+        void Flush();
+    }
+}

--- a/cssrc/Lanterna/Terminal/TerminalFactory.cs
+++ b/cssrc/Lanterna/Terminal/TerminalFactory.cs
@@ -1,0 +1,10 @@
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Factory interface for creating Terminal instances.
+    /// </summary>
+    public interface TerminalFactory
+    {
+        Terminal CreateTerminal();
+    }
+}

--- a/cssrc/Lanterna/Terminal/TerminalPosition.cs
+++ b/cssrc/Lanterna/Terminal/TerminalPosition.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Represents a coordinate in terminal space.
+    /// </summary>
+    public struct TerminalPosition : IComparable<TerminalPosition>
+    {
+        public static readonly TerminalPosition TopLeftCorner = new TerminalPosition(0, 0);
+        public static readonly TerminalPosition Offset1x1 = new TerminalPosition(1, 1);
+
+        public int Column { get; }
+        public int Row { get; }
+
+        public TerminalPosition(int column, int row)
+        {
+            Column = column;
+            Row = row;
+        }
+
+        public int CompareTo(TerminalPosition other)
+        {
+            var cmp = Row.CompareTo(other.Row);
+            if (cmp != 0)
+                return cmp;
+            return Column.CompareTo(other.Column);
+        }
+
+        public TerminalPosition WithRow(int row) => new TerminalPosition(Column, row);
+        public TerminalPosition WithColumn(int column) => new TerminalPosition(column, Row);
+    }
+}

--- a/cssrc/Lanterna/Terminal/TerminalResizeListener.cs
+++ b/cssrc/Lanterna/Terminal/TerminalResizeListener.cs
@@ -1,0 +1,10 @@
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Listener notified when the terminal changes size.
+    /// </summary>
+    public interface TerminalResizeListener
+    {
+        void OnResized(Terminal terminal, TerminalSize newSize);
+    }
+}

--- a/cssrc/Lanterna/Terminal/TerminalSize.cs
+++ b/cssrc/Lanterna/Terminal/TerminalSize.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Represents the dimensions of the terminal in rows and columns.
+    /// </summary>
+    public struct TerminalSize
+    {
+        public static readonly TerminalSize Zero = new TerminalSize(0, 0);
+        public static readonly TerminalSize One = new TerminalSize(1, 1);
+
+        public int Columns { get; }
+        public int Rows { get; }
+
+        public TerminalSize(int columns, int rows)
+        {
+            if (columns < 0 || rows < 0)
+                throw new ArgumentException("Dimensions cannot be negative");
+            Columns = columns;
+            Rows = rows;
+        }
+
+        public TerminalSize WithColumns(int columns) => new TerminalSize(columns, Rows);
+        public TerminalSize WithRows(int rows) => new TerminalSize(Columns, rows);
+    }
+}

--- a/cssrc/Lanterna/Terminal/TerminalTextGraphics.cs
+++ b/cssrc/Lanterna/Terminal/TerminalTextGraphics.cs
@@ -1,0 +1,27 @@
+using Lanterna.Graphics;
+
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Simplified TextGraphics implementation that delegates to a Terminal.
+    /// This is only a minimal placeholder for the full Java class.
+    /// </summary>
+    internal class TerminalTextGraphics : ITextGraphics
+    {
+        private readonly Terminal _terminal;
+
+        public TerminalTextGraphics(Terminal terminal)
+        {
+            _terminal = terminal;
+            Size = terminal.GetTerminalSize();
+        }
+
+        public TerminalSize Size { get; }
+
+        public void SetCharacter(int column, int row, char c)
+        {
+            _terminal.SetCursorPosition(column, row);
+            _terminal.PutCharacter(c);
+        }
+    }
+}

--- a/cssrc/Lanterna/Terminal/TextColor.cs
+++ b/cssrc/Lanterna/Terminal/TextColor.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using System;
+
+namespace Lanterna.Terminal
+{
+    /// <summary>
+    /// Represents a color used by the terminal. This is a simplified
+    /// version of the Java TextColor hierarchy.
+    /// </summary>
+    public interface ITextColor
+    {
+        byte[] GetForegroundSGRSequence();
+        byte[] GetBackgroundSGRSequence();
+        int Red { get; }
+        int Green { get; }
+        int Blue { get; }
+    }
+
+    /// <summary>
+    /// Simple implementation of a 24-bit RGB text color.
+    /// </summary>
+    public class RGB : ITextColor
+    {
+        public int Red { get; }
+        public int Green { get; }
+        public int Blue { get; }
+
+        private readonly byte[] _fg;
+        private readonly byte[] _bg;
+
+        public RGB(int red, int green, int blue)
+        {
+            Red = red;
+            Green = green;
+            Blue = blue;
+            _fg = $"38;2;{red};{green};{blue}".ToCharArray().Select(c => (byte)c).ToArray();
+            _bg = $"48;2;{red};{green};{blue}".ToCharArray().Select(c => (byte)c).ToArray();
+        }
+
+        public byte[] GetForegroundSGRSequence() => (byte[])_fg.Clone();
+        public byte[] GetBackgroundSGRSequence() => (byte[])_bg.Clone();
+    }
+}


### PR DESCRIPTION
## Summary
- add more terminal layer classes for C# port
- rename `ITerminal` to `Terminal`
- stub out adapter and factory implementations

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401ffbfacc83299eeb2fe73f7857cb