### PR TITLE
Add fuller port of ansi and win32 terminals

### DIFF
--- a/cssrc/Lanterna/Terminal/Ansi/ANSITerminal.cs
+++ b/cssrc/Lanterna/Terminal/Ansi/ANSITerminal.cs
@@ -1,0 +1,218 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Lanterna.Terminal.Ansi
+{
+    /// <summary>
+    /// Partial port of the Java ANSITerminal class. Implements common ANSI
+    /// escape sequence handling for basic terminals.
+    /// </summary>
+    public abstract class ANSITerminal : StreamBasedTerminal, ExtendedTerminal
+    {
+        private MouseCaptureMode? _requestedMouseCaptureMode;
+        private MouseCaptureMode? _mouseCaptureMode;
+        private bool _inPrivateMode;
+
+        protected ANSITerminal(Stream input, Stream output, Encoding encoding)
+            : base(input, output, encoding)
+        {
+        }
+
+        private void WriteCSI(params byte[] tail) =>
+            WriteToTerminal(Prepend(new byte[] { 0x1b, (byte)'[' }, tail));
+
+        private void WriteOSC(params byte[] tail) =>
+            WriteToTerminal(Prepend(new byte[] { 0x1b, (byte)']' }, tail));
+
+        private static byte[] Prepend(byte[] head, byte[] tail)
+        {
+            var result = new byte[head.Length + tail.Length];
+            Buffer.BlockCopy(head, 0, result, 0, head.Length);
+            Buffer.BlockCopy(tail, 0, result, head.Length, tail.Length);
+            return result;
+        }
+
+        protected virtual TerminalSize FindTerminalSize()
+        {
+            SaveCursorPosition();
+            SetCursorPosition(5000, 5000);
+            ResetMemorizedCursorPosition();
+            ReportPosition();
+            RestoreCursorPosition();
+            var pos = WaitForCursorPositionReport();
+            if (pos.Column == 0 && pos.Row == 0)
+                return new TerminalSize(80, 24);
+            return new TerminalSize(pos.Column, pos.Row);
+        }
+
+        public override TerminalSize GetTerminalSize() => FindTerminalSize();
+
+        public virtual void SetTerminalSize(int columns, int rows)
+        {
+            WriteCSI(Encoding.GetBytes($"8;{rows};{columns}t"));
+        }
+
+        public virtual void SetTitle(string title)
+        {
+            if (title == null) return;
+            title = title.Replace("\u0007", string.Empty);
+            WriteOSC(Encoding.GetBytes($"2;{title}\u0007"));
+        }
+
+        public virtual void PushTitle() { }
+        public virtual void PopTitle() { }
+
+        public virtual void Iconify() => WriteCSI((byte)'2', (byte)'t');
+        public virtual void Deiconify() => WriteCSI((byte)'1', (byte)'t');
+        public virtual void Maximize() => WriteCSI((byte)'9', (byte)';', (byte)'1', (byte)'t');
+        public virtual void Unmaximize() => WriteCSI((byte)'9', (byte)';', (byte)'0', (byte)'t');
+
+        public virtual void SetMouseCaptureMode(MouseCaptureMode mouseCaptureMode)
+        {
+            _requestedMouseCaptureMode = mouseCaptureMode;
+        }
+
+        public virtual void ScrollLines(int firstLine, int lastLine, int distance)
+        {
+            if (distance == 0 || lastLine < firstLine)
+                return;
+
+            if (firstLine < 0) firstLine = 0;
+
+            var sb = new StringBuilder();
+            sb.Append("\x1b[").Append(firstLine + 1)
+              .Append(';').Append(lastLine + 1).Append('r');
+
+            int target = distance > 0 ? lastLine : firstLine;
+            sb.Append("\x1b[").Append(target + 1).Append(";1H");
+
+            if (distance > 0)
+            {
+                int num = Math.Min(distance, lastLine - firstLine + 1);
+                for (int i = 0; i < num; i++) sb.Append('\n');
+            }
+            else
+            {
+                int num = Math.Min(-distance, lastLine - firstLine + 1);
+                for (int i = 0; i < num; i++) sb.Append("\x1bM");
+            }
+
+            sb.Append("\x1b[r");
+            WriteToTerminal(Encoding.GetBytes(sb.ToString()));
+        }
+
+        public override void SetForegroundColor(ITextColor color) =>
+            WriteCSI(color.GetForegroundSGRSequence());
+
+        public override void SetBackgroundColor(ITextColor color) =>
+            WriteCSI(color.GetBackgroundSGRSequence());
+
+        public override void EnableSGR(SGR sgr)
+        {
+            switch (sgr)
+            {
+                case SGR.Bold: WriteCSI((byte)'1', (byte)'m'); break;
+                case SGR.Reverse: WriteCSI((byte)'7', (byte)'m'); break;
+                case SGR.Underline: WriteCSI((byte)'4', (byte)'m'); break;
+                case SGR.Blink: WriteCSI((byte)'5', (byte)'m'); break;
+                case SGR.Italic: WriteCSI((byte)'3', (byte)'m'); break;
+                case SGR.Bordered: WriteCSI((byte)'5', (byte)'1', (byte)'m'); break;
+                case SGR.Fraktur: WriteCSI((byte)'2', (byte)'0', (byte)'m'); break;
+                case SGR.CrossedOut: WriteCSI((byte)'9', (byte)'m'); break;
+                case SGR.Circled: WriteCSI((byte)'5', (byte)'2', (byte)'m'); break;
+            }
+        }
+
+        public override void DisableSGR(SGR sgr)
+        {
+            switch (sgr)
+            {
+                case SGR.Bold: WriteCSI((byte)'2', (byte)'2', (byte)'m'); break;
+                case SGR.Reverse: WriteCSI((byte)'2', (byte)'7', (byte)'m'); break;
+                case SGR.Underline: WriteCSI((byte)'2', (byte)'4', (byte)'m'); break;
+                case SGR.Blink: WriteCSI((byte)'2', (byte)'5', (byte)'m'); break;
+                case SGR.Italic: WriteCSI((byte)'2', (byte)'3', (byte)'m'); break;
+                case SGR.Bordered: WriteCSI((byte)'5', (byte)'4', (byte)'m'); break;
+                case SGR.Fraktur: WriteCSI((byte)'2', (byte)'3', (byte)'m'); break;
+                case SGR.CrossedOut: WriteCSI((byte)'2', (byte)'9', (byte)'m'); break;
+                case SGR.Circled: WriteCSI((byte)'5', (byte)'4', (byte)'m'); break;
+            }
+        }
+
+        public override void ResetColorAndSGR() => WriteCSI((byte)'0', (byte)'m');
+        public override void ClearScreen() => WriteCSI((byte)'2', (byte)'J');
+
+        public override void EnterPrivateMode()
+        {
+            if (_inPrivateMode)
+                throw new InvalidOperationException("Already in private mode");
+            WriteCSI((byte)'?', (byte)'1', (byte)'0', (byte)'4', (byte)'9', (byte)'h');
+            _inPrivateMode = true;
+        }
+
+        public override void ExitPrivateMode()
+        {
+            if (!_inPrivateMode)
+                throw new InvalidOperationException("Not in private mode");
+            ResetColorAndSGR();
+            SetCursorVisible(true);
+            WriteCSI((byte)'?', (byte)'1', (byte)'0', (byte)'4', (byte)'9', (byte)'l');
+            _inPrivateMode = false;
+        }
+
+        public override void Close()
+        {
+            if (_inPrivateMode)
+                ExitPrivateMode();
+            base.Dispose();
+        }
+
+        public override void SetCursorPosition(int x, int y) =>
+            WriteCSI(Encoding.GetBytes($"{y + 1};{x + 1}H"));
+
+        public override void SetCursorPosition(TerminalPosition position) =>
+            SetCursorPosition(position.Column, position.Row);
+
+        private TerminalPosition WaitForCursorPositionReport()
+        {
+            var buffer = new StringBuilder();
+            while (true)
+            {
+                var ks = ReadInput();
+                if (ks == null) continue;
+                buffer.Append(ks.Character);
+                if (ks.Character == 'R') break;
+            }
+            string result = buffer.ToString();
+            // format ESC [ row ; column R
+            int start = result.IndexOf('[');
+            int sep = result.IndexOf(';');
+            int end = result.IndexOf('R');
+            if (start >= 0 && sep > start && end > sep)
+            {
+                if (int.TryParse(result.Substring(start + 1, sep - start - 1), out int row) &&
+                    int.TryParse(result.Substring(sep + 1, end - sep - 1), out int col))
+                {
+                    return new TerminalPosition(col, row);
+                }
+            }
+            return new TerminalPosition(0, 0);
+        }
+
+        public override TerminalPosition GetCursorPosition()
+        {
+            ResetMemorizedCursorPosition();
+            ReportPosition();
+            var pos = WaitForCursorPositionReport();
+            return new TerminalPosition(pos.Column - 1, pos.Row - 1);
+        }
+
+        public override void SetCursorVisible(bool visible) =>
+            WriteCSI(Encoding.GetBytes($"?25{(visible ? 'h' : 'l')}"));
+
+        protected void ReportPosition() => WriteCSI(Encoding.GetBytes("6n"));
+        protected void RestoreCursorPosition() => WriteCSI(Encoding.GetBytes("u"));
+        protected void SaveCursorPosition() => WriteCSI(Encoding.GetBytes("s"));
+    }
+}

--- a/cssrc/Lanterna/Terminal/Ansi/CygwinTerminal.cs
+++ b/cssrc/Lanterna/Terminal/Ansi/CygwinTerminal.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Lanterna.Terminal.Ansi
+{
+    /// <summary>
+    /// Cygwin specific terminal implementation using stty.
+    /// </summary>
+    public class CygwinTerminal : UnixLikeTTYTerminal
+    {
+        private static readonly string STTY_LOCATION = FindProgram("stty.exe");
+        private static readonly Regex STTY_SIZE_PATTERN = new Regex(@".*rows ([0-9]+);.*columns ([0-9]+);.*");
+        private const string CYGWIN_HOME_ENV = "CYGWIN_HOME";
+
+        public CygwinTerminal(Stream input, Stream output, Encoding encoding)
+            : base(null, input, output, encoding, CtrlCBehaviour.TRAP)
+        {
+        }
+
+        protected override TerminalSize FindTerminalSize()
+        {
+            try
+            {
+                string stty = RunSTTYCommand("-a");
+                var m = STTY_SIZE_PATTERN.Match(stty);
+                if (m.Success)
+                    return new TerminalSize(int.Parse(m.Groups[2].Value), int.Parse(m.Groups[1].Value));
+            }
+            catch
+            {
+            }
+            return new TerminalSize(80, 24);
+        }
+
+        protected override string RunSTTYCommand(params string[] parameters)
+        {
+            var cmd = new List<string> { FindSTTY(), "-F", GetPseudoTerminalDevice() };
+            cmd.AddRange(parameters);
+            return Exec(cmd.ToArray());
+        }
+
+        protected override void Acquire()
+        {
+            base.Acquire();
+        }
+
+        private string FindSTTY() => STTY_LOCATION;
+
+        private string GetPseudoTerminalDevice() => "/dev/pty0";
+
+        private static string FindProgram(string programName)
+        {
+            var cygHome = Environment.GetEnvironmentVariable(CYGWIN_HOME_ENV);
+            if (!string.IsNullOrEmpty(cygHome))
+            {
+                var candidate = Path.Combine(cygHome, "bin", programName);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+
+            var paths = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty).Split(Path.PathSeparator);
+            foreach (var p in paths)
+            {
+                var candidate = Path.Combine(p, programName);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+            return programName;
+        }
+    }
+}

--- a/cssrc/Lanterna/Terminal/Ansi/FixedTerminalSizeProvider.cs
+++ b/cssrc/Lanterna/Terminal/Ansi/FixedTerminalSizeProvider.cs
@@ -1,0 +1,19 @@
+using Lanterna.Terminal;
+
+namespace Lanterna.Terminal.Ansi
+{
+    /// <summary>
+    /// Simple implementation of <see cref="UnixTerminalSizeQuerier"/> that returns a fixed size.
+    /// </summary>
+    public class FixedTerminalSizeProvider : UnixTerminalSizeQuerier
+    {
+        private readonly TerminalSize _size;
+
+        public FixedTerminalSizeProvider(TerminalSize size)
+        {
+            _size = size;
+        }
+
+        public TerminalSize QueryTerminalSize() => _size;
+    }
+}

--- a/cssrc/Lanterna/Terminal/Ansi/StreamBasedTerminal.cs
+++ b/cssrc/Lanterna/Terminal/Ansi/StreamBasedTerminal.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Net.Sockets;
+using Lanterna.Input;
+
+namespace Lanterna.Terminal.Ansi
+{
+    /// <summary>
+    /// Base class for terminals that operate on input and output streams.
+    /// This is only a lightweight placeholder of the Java implementation.
+    /// </summary>
+    public abstract class StreamBasedTerminal : AbstractTerminal
+    {
+        private readonly Stream _input;
+        private readonly Stream _output;
+        protected readonly Encoding Encoding;
+
+        private readonly byte[] _singleChar = new byte[1];
+
+        protected StreamBasedTerminal(Stream input, Stream output, Encoding encoding)
+        {
+            _input = input;
+            _output = output;
+            Encoding = encoding ?? Encoding.UTF8;
+        }
+
+        protected void WriteToTerminal(byte[] bytes)
+        {
+            lock (_output)
+            {
+                _output.Write(bytes, 0, bytes.Length);
+            }
+        }
+
+        private KeyStroke ByteToKeyStroke(int value)
+        {
+            if (value == -1)
+                return null;
+
+            char c = (char)value;
+            if (c == 0x1b)
+                return new KeyStroke(KeyType.Escape);
+            return new KeyStroke(c);
+        }
+
+        private int ReadByteNonBlocking()
+        {
+            switch (_input)
+            {
+                case NetworkStream ns:
+                    return ns.DataAvailable ? ns.ReadByte() : -1;
+                case MemoryStream ms:
+                    if (ms.Position < ms.Length)
+                        return ms.ReadByte();
+                    return -1;
+                case FileStream fs:
+                    if (fs.Length > fs.Position)
+                        return fs.ReadByte();
+                    return -1;
+                default:
+                    return -1;
+            }
+        }
+
+        private int ReadByteBlocking()
+        {
+            int b = _input.ReadByte();
+            return b;
+        }
+
+        protected virtual byte[] TranslateCharacter(char input)
+        {
+            return Encoding.GetBytes(new[] { input });
+        }
+
+        public override void PutCharacter(char c)
+        {
+            WriteToTerminal(TranslateCharacter(c));
+        }
+
+        public override void PutString(string text)
+        {
+            if (text != null)
+            {
+                foreach (var ch in text)
+                    PutCharacter(ch);
+            }
+        }
+
+        public override void Flush()
+        {
+            _output.Flush();
+        }
+
+        public override void Bell()
+        {
+            WriteToTerminal(new byte[] { 7 });
+            Flush();
+        }
+
+        public override byte[] EnquireTerminal(int timeoutMilliseconds)
+        {
+            lock (_output)
+            {
+                _output.WriteByte(5); // ENQ
+                _output.Flush();
+            }
+
+            var buffer = new MemoryStream();
+            var start = DateTime.UtcNow;
+            while ((DateTime.UtcNow - start).TotalMilliseconds < timeoutMilliseconds && ReadByteNonBlocking() is int b && b >= 0)
+            {
+                buffer.WriteByte((byte)b);
+            }
+            return buffer.ToArray();
+        }
+
+        public override KeyStroke PollInput()
+        {
+            int b = ReadByteNonBlocking();
+            return ByteToKeyStroke(b);
+        }
+
+        public override KeyStroke ReadInput()
+        {
+            int b = ReadByteBlocking();
+            return ByteToKeyStroke(b);
+        }
+
+        public override void Dispose()
+        {
+            _input?.Dispose();
+            _output?.Dispose();
+        }
+    }
+}

--- a/cssrc/Lanterna/Terminal/Ansi/TelnetProtocol.cs
+++ b/cssrc/Lanterna/Terminal/Ansi/TelnetProtocol.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+
+namespace Lanterna.Terminal.Ansi
+{
+    /// <summary>
+    /// Constants for the Telnet protocol. Only a subset is provided.
+    /// </summary>
+    internal static class TelnetProtocol
+    {
+        public const byte COMMAND_SUBNEGOTIATION_END = 0xf0;
+        public const byte COMMAND_NO_OPERATION = 0xf1;
+        public const byte COMMAND_DATA_MARK = 0xf2;
+        public const byte COMMAND_BREAK = 0xf3;
+        public const byte COMMAND_INTERRUPT_PROCESS = 0xf4;
+        public const byte COMMAND_ABORT_OUTPUT = 0xf5;
+        public const byte COMMAND_ARE_YOU_THERE = 0xf6;
+        public const byte COMMAND_ERASE_CHARACTER = 0xf7;
+        public const byte COMMAND_ERASE_LINE = 0xf8;
+        public const byte COMMAND_GO_AHEAD = 0xf9;
+        public const byte COMMAND_SUBNEGOTIATION = 0xfa;
+        public const byte COMMAND_WILL = 0xfb;
+        public const byte COMMAND_WONT = 0xfc;
+        public const byte COMMAND_DO = 0xfd;
+        public const byte COMMAND_DONT = 0xfe;
+        public const byte COMMAND_IAC = 0xff;
+
+        public const byte OPTION_TRANSMIT_BINARY = 0x00;
+        public const byte OPTION_ECHO = 0x01;
+        public const byte OPTION_SUPPRESS_GO_AHEAD = 0x03;
+        public const byte OPTION_STATUS = 0x05;
+        public const byte OPTION_TIMING_MARK = 0x06;
+        public const byte OPTION_NAOCRD = 0x0a;
+        public const byte OPTION_NAOHTS = 0x0b;
+        public const byte OPTION_NAOHTD = 0x0c;
+        public const byte OPTION_NAOFFD = 0x0d;
+        public const byte OPTION_NAOVTS = 0x0e;
+        public const byte OPTION_NAOVTD = 0x0f;
+        public const byte OPTION_NAOLFD = 0x10;
+        public const byte OPTION_EXTEND_ASCII = 0x01;
+        public const byte OPTION_TERMINAL_TYPE = 0x18;
+        public const byte OPTION_NAWS = 0x1f;
+        public const byte OPTION_TERMINAL_SPEED = 0x20;
+        public const byte OPTION_TOGGLE_FLOW_CONTROL = 0x21;
+        public const byte OPTION_LINEMODE = 0x22;
+        public const byte OPTION_AUTHENTICATION = 0x25;
+
+        public static readonly IReadOnlyDictionary<string, byte> NAME_TO_CODE;
+        public static readonly IReadOnlyDictionary<byte, string> CODE_TO_NAME;
+
+        static TelnetProtocol()
+        {
+            var name2code = new Dictionary<string, byte>();
+            foreach (var field in typeof(TelnetProtocol).GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static))
+            {
+                if (field.FieldType != typeof(byte))
+                    continue;
+                var name = field.Name;
+                if (name.StartsWith("COMMAND_") || name.StartsWith("OPTION_"))
+                {
+                    name2code[name.Substring(name.IndexOf('_') + 1)] = (byte)field.GetValue(null);
+                }
+            }
+            NAME_TO_CODE = name2code;
+            var rev = new Dictionary<byte, string>();
+            foreach (var kv in name2code)
+                rev[kv.Value] = kv.Key;
+            CODE_TO_NAME = rev;
+        }
+    }
+}

--- a/cssrc/Lanterna/Terminal/Ansi/TelnetTerminal.cs
+++ b/cssrc/Lanterna/Terminal/Ansi/TelnetTerminal.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+
+namespace Lanterna.Terminal.Ansi
+{
+    /// <summary>
+    /// Simplified Telnet terminal implementation over a Socket. Only minimal
+    /// telnet negotiation is performed and the socket streams are used directly.
+    /// </summary>
+    public class TelnetTerminal : ANSITerminal
+    {
+        private readonly Socket _socket;
+
+        public TelnetTerminal(Socket socket, Encoding encoding)
+            : base(new NetworkStream(socket, true), new NetworkStream(socket, true), encoding)
+        {
+            _socket = socket;
+        }
+
+        public Socket RemoteSocket => _socket;
+
+        public override void Close()
+        {
+            base.Close();
+            _socket?.Close();
+        }
+    }
+}

--- a/cssrc/Lanterna/Terminal/Ansi/TelnetTerminalServer.cs
+++ b/cssrc/Lanterna/Terminal/Ansi/TelnetTerminalServer.cs
@@ -1,0 +1,32 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace Lanterna.Terminal.Ansi
+{
+    /// <summary>
+    /// Very small Telnet server accepting incoming connections and creating
+    /// TelnetTerminal instances for them.
+    /// </summary>
+    public class TelnetTerminalServer
+    {
+        private readonly TcpListener _listener;
+        private readonly Encoding _encoding;
+
+        public TelnetTerminalServer(int port, Encoding encoding)
+        {
+            _listener = new TcpListener(IPAddress.Any, port);
+            _listener.Start();
+            _encoding = encoding;
+        }
+
+        public TelnetTerminal AcceptConnection()
+        {
+            var client = _listener.AcceptSocket();
+            client.NoDelay = true;
+            return new TelnetTerminal(client, _encoding);
+        }
+
+        public void Close() => _listener.Stop();
+    }
+}

--- a/cssrc/Lanterna/Terminal/Ansi/UnixLikeTTYTerminal.cs
+++ b/cssrc/Lanterna/Terminal/Ansi/UnixLikeTTYTerminal.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Lanterna.Terminal.Ansi
+{
+    /// <summary>
+    /// Base class for terminals using a TTY device on Unix-like systems.
+    /// </summary>
+    public abstract class UnixLikeTTYTerminal : UnixLikeTerminal
+    {
+        private readonly FileInfo _ttyDev;
+
+        protected UnixLikeTTYTerminal(string ttyDev, Stream input, Stream output, Encoding encoding, CtrlCBehaviour behaviour)
+            : base(input, output, encoding, behaviour)
+        {
+            _ttyDev = ttyDev != null ? new FileInfo(ttyDev) : null;
+        }
+
+        protected override string RunSTTYCommand(params string[] parameters)
+        {
+            var cmd = new List<string>(GetSTTYCommand());
+            if (_ttyDev != null)
+            {
+                cmd.Add("-F");
+                cmd.Add(_ttyDev.FullName);
+            }
+            cmd.AddRange(parameters);
+            return Exec(cmd.ToArray());
+        }
+
+        protected string Exec(params string[] cmd)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = cmd[0],
+                RedirectStandardInput = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            for (int i = 1; i < cmd.Length; i++)
+                psi.ArgumentList.Add(cmd[i]);
+            if (_ttyDev != null)
+                psi.RedirectStandardInput = true;
+
+            using var process = Process.Start(psi);
+            if (process == null)
+                return string.Empty;
+            string output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+            return output.Trim();
+        }
+
+        protected virtual string[] GetSTTYCommand() => new[] { "/usr/bin/env", "stty" };
+    }
+}

--- a/cssrc/Lanterna/Terminal/Ansi/UnixLikeTerminal.cs
+++ b/cssrc/Lanterna/Terminal/Ansi/UnixLikeTerminal.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using System.Text;
+using Lanterna.Input;
+
+namespace Lanterna.Terminal.Ansi
+{
+    /// <summary>
+    /// Base for terminals behaving like Unix consoles.
+    /// </summary>
+    public abstract class UnixLikeTerminal : ANSITerminal
+    {
+        public enum CtrlCBehaviour
+        {
+            TRAP,
+            CTRL_C_KILLS_APPLICATION
+        }
+
+        protected UnixLikeTerminal(Stream input, Stream output, Encoding encoding, CtrlCBehaviour behaviour)
+            : base(input, output, encoding)
+        {
+        }
+
+        protected abstract void RegisterTerminalResizeListener(System.Action onResize);
+        protected abstract void SaveTerminalSettings();
+        protected abstract void RestoreTerminalSettings();
+        protected abstract void KeyEchoEnabled(bool enabled);
+        protected abstract void CanonicalMode(bool enabled);
+        protected abstract void KeyStrokeSignalsEnabled(bool enabled);
+        public virtual KeyStroke IsCtrlC(KeyStroke key) => key;
+    }
+}

--- a/cssrc/Lanterna/Terminal/Ansi/UnixTerminal.cs
+++ b/cssrc/Lanterna/Terminal/Ansi/UnixTerminal.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using System.Text;
+
+namespace Lanterna.Terminal.Ansi
+{
+    /// <summary>
+    /// Simplified Unix terminal implementation.
+    /// </summary>
+    public class UnixTerminal : UnixLikeTTYTerminal
+    {
+        public UnixTerminal() : this(Stream.Null, Stream.Null, Encoding.UTF8) { }
+
+        public UnixTerminal(Stream input, Stream output, Encoding encoding)
+            : base("/dev/tty", input, output, encoding, CtrlCBehaviour.CTRL_C_KILLS_APPLICATION)
+        {
+        }
+    }
+}

--- a/cssrc/Lanterna/Terminal/Ansi/UnixTerminalSizeQuerier.cs
+++ b/cssrc/Lanterna/Terminal/Ansi/UnixTerminalSizeQuerier.cs
@@ -1,0 +1,12 @@
+using Lanterna.Terminal;
+
+namespace Lanterna.Terminal.Ansi
+{
+    /// <summary>
+    /// Strategy interface for querying terminal size on Unix-like systems.
+    /// </summary>
+    public interface UnixTerminalSizeQuerier
+    {
+        TerminalSize QueryTerminalSize();
+    }
+}

--- a/cssrc/Lanterna/Terminal/Win32/WinDef.cs
+++ b/cssrc/Lanterna/Terminal/Win32/WinDef.cs
@@ -1,0 +1,37 @@
+namespace Lanterna.Terminal.Win32
+{
+    /// <summary>
+    /// Placeholder structures for Windows console interop.
+    /// They only contain the fields needed by the stub classes.
+    /// </summary>
+    public static class WinDef
+    {
+        public struct COORD
+        {
+            public short X;
+            public short Y;
+        }
+
+        public struct SMALL_RECT
+        {
+            public short Left;
+            public short Top;
+            public short Right;
+            public short Bottom;
+        }
+
+        public struct CONSOLE_SCREEN_BUFFER_INFO
+        {
+            public COORD dwSize;
+            public COORD dwCursorPosition;
+            public short wAttributes;
+            public SMALL_RECT srWindow;
+            public COORD dwMaximumWindowSize;
+        }
+
+        public struct INPUT_RECORD { }
+        public struct KEY_EVENT_RECORD { }
+        public struct MOUSE_EVENT_RECORD { }
+        public struct WINDOW_BUFFER_SIZE_RECORD { public COORD dwSize; }
+    }
+}

--- a/cssrc/Lanterna/Terminal/Win32/Wincon.cs
+++ b/cssrc/Lanterna/Terminal/Win32/Wincon.cs
@@ -1,0 +1,12 @@
+namespace Lanterna.Terminal.Win32
+{
+    /// <summary>
+    /// Small collection of constants typically provided by the Win32 API.
+    /// </summary>
+    public static class Wincon
+    {
+        public const int ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
+        public const int DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
+        public const int ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200;
+    }
+}

--- a/cssrc/Lanterna/Terminal/Win32/WindowsConsoleInputStream.cs
+++ b/cssrc/Lanterna/Terminal/Win32/WindowsConsoleInputStream.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Lanterna.Terminal.Win32
+{
+    /// <summary>
+    /// Minimal stand-in for the Windows console input stream.
+    /// </summary>
+    public class WindowsConsoleInputStream : Stream
+    {
+        private readonly Stream _stream;
+
+        public WindowsConsoleInputStream(Encoding encoding)
+        {
+            _stream = Console.OpenStandardInput();
+        }
+
+        public override bool CanRead => _stream.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _stream.Length;
+        public override long Position { get => _stream.Position; set => _stream.Position = value; }
+        public override void Flush() => _stream.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => _stream.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => _stream.Seek(offset, origin);
+        public override void SetLength(long value) => _stream.SetLength(value);
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/cssrc/Lanterna/Terminal/Win32/WindowsConsoleOutputStream.cs
+++ b/cssrc/Lanterna/Terminal/Win32/WindowsConsoleOutputStream.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Lanterna.Terminal.Win32
+{
+    /// <summary>
+    /// Minimal stand-in for the Windows console output stream.
+    /// </summary>
+    public class WindowsConsoleOutputStream : Stream
+    {
+        private readonly Stream _stream;
+
+        public WindowsConsoleOutputStream(Encoding encoding)
+        {
+            _stream = Console.OpenStandardOutput();
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => _stream.CanWrite;
+        public override long Length => _stream.Length;
+        public override long Position { get => _stream.Position; set => _stream.Position = value; }
+        public override void Flush() => _stream.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => _stream.Seek(offset, origin);
+        public override void SetLength(long value) => _stream.SetLength(value);
+        public override void Write(byte[] buffer, int offset, int count) => _stream.Write(buffer, offset, count);
+    }
+}

--- a/cssrc/Lanterna/Terminal/Win32/WindowsTerminal.cs
+++ b/cssrc/Lanterna/Terminal/Win32/WindowsTerminal.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Lanterna.Terminal.Ansi;
+
+namespace Lanterna.Terminal.Win32
+{
+    /// <summary>
+    /// Basic Windows console terminal implementation using Console APIs.
+    /// </summary>
+    public class WindowsTerminal : UnixLikeTerminal
+    {
+        public WindowsTerminal()
+            : this(Console.OpenStandardInput(), Console.OpenStandardOutput(), Encoding.UTF8, CtrlCBehaviour.CTRL_C_KILLS_APPLICATION)
+        {
+        }
+
+        public WindowsTerminal(Stream input, Stream output, Encoding encoding, CtrlCBehaviour behaviour)
+            : base(input, output, encoding, behaviour)
+        {
+        }
+
+        protected override void RegisterTerminalResizeListener(Action onResize)
+        {
+            // .NET does not expose a resize event for the console
+        }
+
+        protected override void SaveTerminalSettings() { }
+        protected override void RestoreTerminalSettings() { }
+        protected override void KeyEchoEnabled(bool enabled) { Console.TreatControlCAsInput = !enabled; }
+        protected override void CanonicalMode(bool enabled) { }
+        protected override void KeyStrokeSignalsEnabled(bool enabled) { Console.TreatControlCAsInput = !enabled; }
+
+        protected override TerminalSize FindTerminalSize()
+        {
+            return new TerminalSize(Console.WindowWidth, Console.WindowHeight);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend ANSI terminal classes with concrete implementations
- implement minimal Cygwin terminal with stty integration
- enrich StreamBasedTerminal with basic input handling
- provide simple Telnet server and client over sockets
- flesh out Windows console stream wrappers and terminal

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684028b414f883299a5d3ca8f698156b